### PR TITLE
remove fake NA clones

### DIFF
--- a/epitope_data_analysis/add_dextramer_binding_data.R
+++ b/epitope_data_analysis/add_dextramer_binding_data.R
@@ -20,7 +20,7 @@ Idents(sc) = 'integrated_annotations'
 
 
 # Add clonotype size
-sc$patient_clonotype = paste0(sc$patient, '_', sc$TCR_clonotype_id)
+sc$patient_clonotype = str_c(sc$patient, '_', sc$TCR_clonotype_id)
 
 df = sc@meta.data %>% 
 	group_by(patient_clonotype) %>% 


### PR DESCRIPTION
When concatenating strings, `paste` will convert NAs to string - `1_NA`, `2_NA` etc become "fake clones".
`str_c` instead will just return NA in those cases, which is the expected behaviour.